### PR TITLE
修复当目录超过两页后，第一页后的目录页面会丢失页眉页脚

### DIFF
--- a/nuaathesis.cls
+++ b/nuaathesis.cls
@@ -64,6 +64,7 @@
 
 %% fancyhdr package
 %% 正文页眉页脚
+\pagestyle{fancy}
 \fancypagestyle{plain}{%
   \fancyhf{}
   \fancyhead[L]{\setlength{\unitlength}{1mm}
@@ -75,6 +76,8 @@
   \renewcommand{\headrulewidth}{0.7pt}
   \renewcommand{\footrulewidth}{0.7pt}
 }
+\appto\frontmatter{\pagestyle{plain}}
+\appto\mainmatter{\pagestyle{plain}}
 
 %% ctex & xeCJK package
 


### PR DESCRIPTION
ATT. 
fancypage使用姿势问题。
环境：MikTex 2.9 /w Windows 10
修复前：
 ![图片](https://dn-coding-net-production-pp.qbox.me/13c46a67-7ac7-4407-97ed-096731d2ce91.png) 
修复后：
 ![图片](https://dn-coding-net-production-pp.qbox.me/929b6c2c-b1ce-48e8-bcb5-f21077509f83.png) 
