### PR TITLE
修正封面空格字距

### DIFF
--- a/nuaathesis.cfg
+++ b/nuaathesis.cfg
@@ -31,10 +31,10 @@
 \newcommand\nuaa@label@title{题\quad 目}
 \newcommand\nuaa@label@teamname{团队名称}
 \newcommand\nuaa@label@author{学生姓名}
-\newcommand\nuaa@label@studentid{学\hspace{2em} 号}
-\newcommand\nuaa@label@college{学\hspace{2em} 院}
-\newcommand\nuaa@label@major{专\hspace{2em} 业}
-\newcommand\nuaa@label@classid{班\hspace{2em} 级}
+\newcommand\nuaa@label@studentid{学　　号}
+\newcommand\nuaa@label@college{学　　院}
+\newcommand\nuaa@label@major{专　　业}
+\newcommand\nuaa@label@classid{班　　级}
 \newcommand\nuaa@label@advisor{指导教师}
 
 %%==============================


### PR DESCRIPTION
在 CKJ 之间使用 `hspace` 貌似会插入额外的英文空格，导致上下无法对齐
（虽然只有0.x em），实在没想到更好的办法，就用全角空格代替了，至少
全角空格能做到严格的对齐。